### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -2,6 +2,8 @@
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
 
 name: Node.js CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Coveros/codeveros-ms/security/code-scanning/2](https://github.com/Coveros/codeveros-ms/security/code-scanning/2)

To fix the issue, add a `permissions` block at the beginning of the workflow file, either at the root level (which applies to all jobs unless overridden), or at the individual job level. The minimal sufficient permissions for this workflow are `contents: read`, since the actions used (checkout, setup-node, install dependencies, build, lint, and test) only need to read the repository, not write to it or modify pull requests/issues. The block should be added after the `name` field and before the `on` field to set root-level permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
