### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -2,6 +2,8 @@
 # For more information see: https://help.github.com/actions/language-and-framework-guides/publishing-nodejs-packages
 
 name: Node.js Package
+permissions:
+  contents: read
 
 on:
   release:


### PR DESCRIPTION
Potential fix for [https://github.com/Coveros/codeveros-ms/security/code-scanning/3](https://github.com/Coveros/codeveros-ms/security/code-scanning/3)

To fix the problem, add a `permissions` block that restricts the permissions of the workflow’s jobs. Since neither job (build or publish-npm) writes to the repository or performs privileged operations outside of reading files and publishing to npm, set `contents: read` in the root of the workflow. This will restrict the workflow’s access token to only read repository contents, as needed for checking out code and testing, and for publishing packages. Insert the following block after the `name:` field in the YAML file:

```yaml
permissions:
  contents: read
```

No imports or other code changes are necessary; simply add the permissions block at the workflow root, before `on:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
